### PR TITLE
Add a generator for files from Jinja templates

### DIFF
--- a/generators.core
+++ b/generators.core
@@ -78,4 +78,4 @@ generators:
           type:   The file type of the rendered template (vhdlSource, verilogSource, etc.)
         template: The file name of the template within the templates subdirectory
 
-      Examples of template usage are in The examples directory.
+      Examples of template usage are in the examples directory.

--- a/generators.core
+++ b/generators.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : fusesoc:utils:generators:0.1.4
+name : fusesoc:utils:generators:0.1.5
 
 generators:
   custom:
@@ -74,8 +74,16 @@ generators:
       The generator requires the following parameters:
 
         output_file:
+
           name:   The file name for the rendered template
           type:   The file type of the rendered template (vhdlSource, verilogSource, etc.)
-        template: The file name of the template within the templates subdirectory
+
+        template: The file name of the template
+
+        template_path (optional): The directory containing the template.
+
+            If this parameter isn't specified the default is to use the
+            calling core's directory followed by the templates
+            directory for this generator.
 
       Examples of template usage are in the examples directory.

--- a/generators.core
+++ b/generators.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : fusesoc:utils:generators:0.1.1
+name : fusesoc:utils:generators:0.1.4
 
 generators:
   custom:

--- a/generators.core
+++ b/generators.core
@@ -62,3 +62,20 @@ generators:
                        and the icepll generator will create a list of parameters that
                        can be included in the parameter list of the user-instantiated
                        component (default: false)
+
+  template:
+    interpreter: python
+    command: template/template_generator.py
+    description: Generate a file from a Jinja template
+    usage: |
+      The template generator uses the provided YAML description to populate
+      a Jinja template.
+
+      The generator requires the following parameters:
+
+        output_file:
+          name:   The file name for the rendered template
+          type:   The file type of the rendered template (vhdlSource, verilogSource, etc.)
+        template: The file name of the template within the templates subdirectory
+
+      Examples of template usage are in The examples directory.

--- a/template/examples/add.v
+++ b/template/examples/add.v
@@ -1,0 +1,12 @@
+module add #(
+  parameter WIDTH = 16)
+(
+  input                  clk,
+  input      [WIDTH-1:0] a, b,
+  output reg [WIDTH:0]   c
+);
+
+  always @(posedge clk)
+    c <= a + b;
+
+endmodule

--- a/template/examples/constants_test.sv
+++ b/template/examples/constants_test.sv
@@ -1,0 +1,15 @@
+import constants_pkg::*;
+
+module constants_test;
+
+  initial
+  begin
+    $display("WORD_SIZE: %d",  word_size);
+    $display("ITERATIONS: %d", iterations);
+    $display("LOW_AREA: %d",   low_area);
+    $display("IMPL: %s",       impl);
+    $finish;
+  end
+
+endmodule
+

--- a/template/examples/constants_test.vhd
+++ b/template/examples/constants_test.vhd
@@ -1,0 +1,20 @@
+USE work.constants_pkg.ALL;
+
+ENTITY constants_test IS
+END ENTITY;
+
+ARCHITECTURE test OF constants_test IS
+BEGIN
+
+  sim : PROCESS
+  BEGIN
+    REPORT "WORD_SIZE: "  & INTEGER'IMAGE(word_size) & LF;
+    REPORT "ITERATIONS: " & INTEGER'IMAGE(iterations) & LF;
+    REPORT "LOW_AREA: "   & BOOLEAN'IMAGE(low_area) & LF;
+    REPORT "IMPL: "       & impl & LF;
+
+    std.env.finish(0);
+    WAIT;
+  END PROCESS;
+
+END test ; --constants_test

--- a/template/examples/generators_template_constraints.core
+++ b/template/examples/generators_template_constraints.core
@@ -1,0 +1,56 @@
+CAPI=2:
+name:        fusesoc:utils:generators_template_constraints:0.1
+description: Simple example of generating SDC and UCF constraints
+
+filesets:
+
+    hdl:
+        files:     [add.v]
+        file_type: verilogSource
+        depend:    ["fusesoc:utils:generators"]
+
+generate:
+
+    ise_constraints:
+        generator: template
+        parameters:
+            output_file:  {name: add.ucf, type: UCF}
+            template:     ucf.j2
+            clock_name: clk
+            clock_freq: "123 MHz"
+
+    quartus_constraints:
+        generator: template
+        parameters:
+            output_file:  {name: add.sdc, type: SDC}
+            template:     sdc.j2
+            clock_name:   clk
+            clock_period: '"234 MHz"'
+            input_delay:  0
+            output_delay: 0
+
+targets:
+
+    default: &default
+        filesets: [hdl]
+        toplevel: [add]
+
+    ise:
+        <<: *default
+        generate: [ise_constraints]
+        default_tool: ise
+        tools:
+            ise:
+                family:  spartan6l
+                device:  XC6SLX75L
+                package: CSG484
+                speed:   "-1L"
+
+    quartus:
+        <<: *default
+        generate: [quartus_constraints]
+        default_tool: quartus
+        tools:
+            quartus:
+                family: "Cyclone V"
+                device: 5CEBA2F17C7

--- a/template/examples/generators_template_local.core
+++ b/template/examples/generators_template_local.core
@@ -1,0 +1,28 @@
+CAPI=2:
+name:        fusesoc:utils:generators_template_local:0.1
+description: Silly example using a template from a core rather than the generator
+
+filesets:
+
+    tb:
+        files:     [test_add.v]
+        file_type: verilogSource
+        depend:    ["fusesoc:utils:generators"]
+
+generate:
+
+    adder:
+        generator: template
+        parameters:
+            output_file:  {name: my_add.v, type: verilogSource}
+            template:     my_templates/adder.j2
+            clock:        clk
+            adder_name:   my_add
+
+targets:
+
+    default:
+        default_tool: modelsim
+        filesets: [tb]
+        generate: [adder]
+        toplevel: [test_add]

--- a/template/examples/generators_template_package.core
+++ b/template/examples/generators_template_package.core
@@ -1,0 +1,59 @@
+CAPI=2:
+name:        fusesoc:utils:generators_template_package:0.1
+description: Simple example of generating packages
+
+filesets:
+
+    vhdl:
+        files:     [constants_test.vhd]
+        file_type: vhdlSource-2008
+        depend:    ["fusesoc:utils:generators"]
+
+    sv:
+        files:     [constants_test.sv]
+        file_type: systemVerilogSource
+        depend:    ["fusesoc:utils:generators"]
+
+generate:
+
+    constants_vhdl:
+        generator: template
+        position:  first
+        parameters:
+            output_file:  {name: constants_pkg.vhd, type: vhdlSource}
+            template:     constants_pkg_vhd.j2
+            package_name: constants_pkg
+            constants:
+                - {name: word_size,  type: POSITIVE, value: 32}
+                - {name: iterations, type: POSITIVE, value: 100}
+                - {name: low_area,   type: BOOLEAN,  value: true}
+                - {name: impl,       type: STRING,   value: '"tiny"'}
+
+    constants_sv:
+        generator: template
+        position:  first
+        parameters:
+            output_file:  {name: constants_pkg.sv, type: systemVerilogSource}
+            template:     constants_pkg_sv.j2
+            package_name: constants_pkg
+            constants:
+                - {name: word_size,  type: int,    value: 48}
+                - {name: iterations, type: int,    value: 123}
+                - {name: low_area,   type: int,    value: 0}
+                - {name: impl,       type: string, value: '"huge"'}
+
+targets:
+
+    default: &default
+        default_tool: modelsim
+        toplevel:     [constants_test]
+
+    sim_vhdl:
+        <<: *default
+        filesets: [vhdl]
+        generate: [constants_vhdl]
+
+    sim_sv:
+        <<: *default
+        filesets: [sv]
+        generate: [constants_sv]

--- a/template/examples/my_templates/adder.j2
+++ b/template/examples/my_templates/adder.j2
@@ -1,0 +1,20 @@
+{#
+Example of a template that's shipped with a core rather than fusesoc-generators
+
+Required varaibles:
+
+adder_name - The name of the adder module
+clock      - The name of the clock signal
+#}
+module {{ adder_name }} #(
+  parameter WIDTH = 16)
+(
+  input                  {{ clock }},
+  input      [WIDTH-1:0] a, b,
+  output reg [WIDTH:0]   c
+);
+
+  always @(posedge {{ clock }})
+    c <= a + b;
+
+endmodule

--- a/template/examples/test_add.v
+++ b/template/examples/test_add.v
@@ -1,0 +1,54 @@
+module test_add;
+
+  localparam period = 10;
+
+  reg  clock;
+  reg  [15:0] a, b;
+  reg  [16:0] expected;
+
+  wire [16:0] c;
+
+  integer errors = 0, cycle_count = 0, total_cycles = 100;
+
+  my_add dut (.clk (clock), .a (a), .b (b), .c (c));
+
+  initial
+  begin
+    clock = 0;
+    forever #(period/2) clock = ~clock;
+  end
+
+  // Stimulus
+  always @(posedge clock)
+  begin
+    #1
+    a = $urandom;
+    b = $urandom;
+    cycle_count = cycle_count + 1;
+  end
+
+  // Model
+  always @(posedge clock)
+  begin
+    expected = a + b;
+  end
+
+  // Check results on the falling edge of the clock
+  always @(negedge clock)
+  begin
+
+    if (cycle_count == total_cycles)
+    begin
+      $display("Finished simulation. Ran %d tests with %d errors.", cycle_count, errors);
+      $finish;
+    end
+
+    if (c !== expected)
+    begin
+      errors = errors + 1;
+      $display("Error! Got %d + %d = %d but expected %d", a, b, c, expected);
+    end
+
+  end
+
+endmodule

--- a/template/template_generator.py
+++ b/template/template_generator.py
@@ -10,12 +10,16 @@ class TemplateGenerator(Generator):
         output_file   = self.config.get('output_file')
         template_name = self.config.get('template')
 
-        # Look for Jinja templates in the "templates" directory beneath this
-        # script's location
+        # Look for Jinja templates from the core or in the "templates"
+        # directory beneath this script's location
+        template_path = [self.files_root]
+
         script_dir   = os.path.dirname(sys.argv[0])
         template_dir = os.path.join(script_dir, 'templates')
 
-        env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True, lstrip_blocks=True)
+        template_path.append(template_dir)
+
+        env = Environment(loader=FileSystemLoader(template_path), trim_blocks=True, lstrip_blocks=True)
 
         template = env.get_template(template_name)
 

--- a/template/template_generator.py
+++ b/template/template_generator.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+from fusesoc.capi2.generator import Generator
+from jinja2 import Environment, FileSystemLoader
+
+class TemplateGenerator(Generator):
+    def run(self):
+
+        output_file   = self.config.get('output_file')
+        template_name = self.config.get('template')
+
+        # Look for Jinja templates in the "templates" directory beneath this
+        # script's location
+        script_dir   = os.path.dirname(sys.argv[0])
+        template_dir = os.path.join(script_dir, 'templates')
+
+        env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True, lstrip_blocks=True)
+
+        template = env.get_template(template_name)
+
+        template.stream(self.config).dump(output_file['name'])
+
+        self.add_files([{output_file['name'] : {'file_type' : output_file['type']}}])
+
+g = TemplateGenerator()
+g.run()
+g.write()

--- a/template/template_generator.py
+++ b/template/template_generator.py
@@ -15,7 +15,7 @@ class TemplateGenerator(Generator):
         # beneath this script's location
         default_template_path = [self.files_root]
 
-        script_dir   = os.path.dirname(sys.argv[0])
+        script_dir   = os.path.dirname(__file__)
         template_dir = os.path.join(script_dir, 'templates')
 
         default_template_path.append(template_dir)
@@ -30,6 +30,7 @@ class TemplateGenerator(Generator):
 
         self.add_files([{output_file['name'] : {'file_type' : output_file['type']}}])
 
-g = TemplateGenerator()
-g.run()
-g.write()
+if __name__ == '__main__':
+    g = TemplateGenerator()
+    g.run()
+    g.write()

--- a/template/template_generator.py
+++ b/template/template_generator.py
@@ -10,14 +10,17 @@ class TemplateGenerator(Generator):
         output_file   = self.config.get('output_file')
         template_name = self.config.get('template')
 
-        # Look for Jinja templates from the core or in the "templates"
-        # directory beneath this script's location
-        template_path = [self.files_root]
+        # Allow the user to specify where to look for Jinja templates, but by
+        # default look in the core's directory or in the "templates" directory
+        # beneath this script's location
+        default_template_path = [self.files_root]
 
         script_dir   = os.path.dirname(sys.argv[0])
         template_dir = os.path.join(script_dir, 'templates')
 
-        template_path.append(template_dir)
+        default_template_path.append(template_dir)
+
+        template_path = self.config.get('template_path', default_template_path)
 
         env = Environment(loader=FileSystemLoader(template_path), trim_blocks=True, lstrip_blocks=True)
 

--- a/template/templates/constants_pkg_sv.j2
+++ b/template/templates/constants_pkg_sv.j2
@@ -1,0 +1,28 @@
+{#
+Render a SystemVerilog package containing constants
+
+Required varaibles:
+
+package_name - The name of the SystemVerilog package
+constants    - A list of dicts each containing a constant's name, type, and value
+
+Example:
+
+    constants_sv:
+        generator: template
+        position:  first
+        parameters:
+            output_file:  {name: constants_pkg.sv, type: systemVerilogSource}
+            template:     constants_pkg_sv.j2
+            package_name: constants_pkg
+            constants:
+                - {name: word_size,  type: int,    value: 48}
+                - {name: iterations, type: int,    value: 123}
+                - {name: low_area,   type: int,    value: 0}
+                - {name: impl,       type: string, value: '"huge"'}
+#}
+package {{ package_name }};
+{% for c in constants %}
+    const {{ c.type }} {{ c.name }} = {{ c.value }};
+{% endfor %}
+endpackage

--- a/template/templates/constants_pkg_vhd.j2
+++ b/template/templates/constants_pkg_vhd.j2
@@ -1,0 +1,30 @@
+{#
+Render a VHDL package containing constants
+
+Required varaibles:
+
+package_name - The name of the VHDL package
+constants    - A list of dicts each containing a constant's name, type, and value
+
+Example:
+
+generate:
+
+    constants_vhdl:
+        generator: template
+        position:  first
+        parameters:
+            output_file:  {name: constants_pkg.vhd, type: vhdlSource}
+            template:     constants_pkg_vhd.j2
+            package_name: constants_pkg
+            constants:
+                - {name: word_size,  type: POSITIVE, value: 32}
+                - {name: iterations, type: POSITIVE, value: 100}
+                - {name: low_area,   type: BOOLEAN,  value: true}
+                - {name: impl,       type: STRING,   value: '"tiny"'}
+#}
+PACKAGE {{ package_name }} IS
+{% for c in constants %}
+  CONSTANT {{ c.name }} : {{ c.type }} := {{ c.value }};
+{% endfor %}
+END PACKAGE;

--- a/template/templates/sdc.j2
+++ b/template/templates/sdc.j2
@@ -1,0 +1,18 @@
+{#
+Render a basic Intel Quartus SDC file
+
+Variables:
+
+clock_name   - Name of the clock signal (default: clk)
+clock_period - Quartus supports both a period in ns or a string like "375 MHz" (default: 1.0)
+input_delay  - Value applied with set_input_delay to all inputs (default: 0)
+output_delay - Value applied with set_output_delay to all outputs (default: 0)
+-#}
+
+{% set clk = clock_name|default(clk) -%}
+
+create_clock -name {{clk}} -period {{clock_period|default(1.0)}} [get_ports {{clk}}]
+
+set_input_delay  -clock {{clk}} {{input_delay|default(0)}}  [all_inputs]
+set_output_delay -clock {{clk}} {{output_delay|default(0)}} [all_outputs]
+

--- a/template/templates/ucf.j2
+++ b/template/templates/ucf.j2
@@ -1,0 +1,16 @@
+{#
+Render a basic Xilinx ISE UCF file
+
+Variables:
+
+clock_name - Name of the clock signal (default: clk)
+clock_freq - Clock frequency in a string like 375 MHz (default: 500 MHz)
+
+-#}
+
+{% set clk = clock_name|default(clk) -%}
+
+
+NET "{{clk}}" TNM_NET = {{clk}};
+TIMESPEC TS_{{clk}} = PERIOD "{{clk}}" {{clock_freq|default("500 MHz")}} HIGH 50%;
+


### PR DESCRIPTION
Currently includes templates for generating VHDL and SystemVerilog packages containing constants and basic UCF and SDC constraints.