### PR TITLE
Support running in containers and passing arguments

### DIFF
--- a/chisel.py
+++ b/chisel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from fusesoc.capi2.generator import Generator
 import os
 import shutil
@@ -12,6 +12,7 @@ class ChiselGenerator(Generator):
         buildtool = self.config.get('buildtool', "mill")
         chiselproject = self.config.get('chiselproject', None)
         outputdir = self.config.get('outputdir', "generated")
+        extraargs = self.config.get('extraargs', "")
         if buildtool == "mill" and chiselproject == None:
             print("The parameter 'chiselproject' must be defined.")
             exit(1)
@@ -40,11 +41,11 @@ class ChiselGenerator(Generator):
             exit(1)
         print("Using build tool from: " + buildcmd[0])
 
-        # Define command based on build tool
+        # Define command and arguments based on build tool
         if buildtool == "mill":
-            args = [chiselproject + ".run", "--target-dir=" + outputdir]
+            args = ["-i", chiselproject + ".run", "--target-dir=" + outputdir] + extraargs.split(" ")
         elif buildtool == "sbt":
-            args = ["run --target-dir=" + outputdir]
+            args = ["run --target-dir=" + outputdir] + extraargs.split(" ")
 
         # Concatenate environment variables from system + user defined
         d = os.environ
@@ -53,6 +54,10 @@ class ChiselGenerator(Generator):
 
         # Call build tool
         cmd = buildcmd + args
+        if os.getenv('EDALIZE_LAUNCHER'):
+            cmd = [os.getenv('EDALIZE_LAUNCHER')] + cmd
+
+        print("Working dir:", cwd)
         print("Running:", " ".join(cmd))
         rc = subprocess.call(cmd, env=d, cwd=cwd)
 

--- a/generators.core
+++ b/generators.core
@@ -107,6 +107,7 @@ generators:
         outputdir (str): Output directory to be passed to build tool for generated
                          verilog files from Chisel sources. Must match path used in
                          "output: files:" section.
+        extraargs (str): Extra arguments to be passed to the build tool.
         chiselproject (str): Chisel project name to be passed to the build tool.
         copy_core (bool): Copy the working directory to a temporary location and run
                           the command from there

--- a/template/examples/generators_chisel.core
+++ b/template/examples/generators_chisel.core
@@ -16,6 +16,7 @@ generate:
       outputdir: . # Optional, set to "generated" as default
       env: # Optional environment variables
         BOARD: polarfireeval
+      extraargs: "-board polarfireeval" # Optional arguments to build tool
       chiselproject: blinky # Mandatory if using mill
       copy_core: true # Build from fresh directory
       output:


### PR DESCRIPTION
This PR adds support for running the generator in container using the `EDALIZE_LAUNCHER` var.
Also added support for passing arguments to the build tool.

Example script for `EDALIZE_LAUNCHER`:

```python
#!/usr/bin/python
import os
import subprocess
import sys

containers = {
    'yosys'        : 'hdlc/yosys',
    'nextpnr-ice40': 'hdlc/nextpnr',
    'nextpnr-ecp5' : 'hdlc/nextpnr',
    'icepack'      : 'hdlc/icestorm',
    'ecppack'      : 'hdlc/prjtrellis',
    'icetime'      : 'hdlc/icestorm',
    'icebox_stat'  : 'hdlc/icestorm',
    'ghdl'         : 'ghdl/ghdl:buster-llvm-7',
    'verilator'    : 'verilator/verilator',
    'mill'         : 'adoptopenjdk:8u282-b08-jre-hotspot',
}
tool = os.path.basename(sys.argv[1])
if tool in containers:
    (build_root, work) = os.path.split(os.getcwd())
    dockerEnv = ""
    for k in os.environ:
        dockerEnv = dockerEnv + "-e " + k + "='" + os.environ[k] + "' "
    # print(dockerEnv)
    cmd = ['docker','run','--rm',
                     '-v', build_root+':/src',
                     '-e', dockerEnv,
                     '-w', '/src/'+work,
                     containers[tool],
                     './scripts/'+tool]  + sys.argv[2:]
    subprocess.call(cmd, env=os.environ)
else:
    subprocess.call(sys.argv[1:])
```

Run as:

```sh
❯ EDALIZE_LAUNCHER=$(realpath ../runme.py) fusesoc run --target=polarfireeval_es --setup carlosedp:demo:chiselblinky:0
INFO: Preparing fusesoc:utils:generators:0.1.6
INFO: Preparing carlosedp:demo:chiselblinky:0
INFO: Generating carlosedp:demo:chiselblinky-polarfireeval:0
Using build tool from: /var/folders/dv/d24tqkhn7zg55vj4ttrqq35m0000gp/T/tmp6o7hcsmh/core/scripts/mill
Working dir: /var/folders/dv/d24tqkhn7zg55vj4ttrqq35m0000gp/T/tmp6o7hcsmh/core
Running: /Users/cdepaula/projects/fusesoc/runme.py /var/folders/dv/d24tqkhn7zg55vj4ttrqq35m0000gp/T/tmp6o7hcsmh/core/scripts/mill -i blinky.run --target-dir=generated -board polarfireeval
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   140  100   140    0     0    289      0 --:--:-- --:--:-- --:--:--   289
100   622  100   622    0     0    988      0 --:--:-- --:--:-- --:--:--   988
100 57.8M  100 57.8M    0     0  15.2M      0  0:00:03  0:00:03 --:--:-- 20.0M
Downloading https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-core_2.13/1.9.6/scalate-core_2.13-1.9.6.pom
Downloaded https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-core_2.13/1.9.6/scalate-core_2.13-1.9.6.pom
Downloading https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-util_2.13/1.9.6/scalate-util_2.13-1.9.6.pom
Downloaded https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-util_2.13/1.9.6/scalate-util_2.13-1.9.6.pom
Downloading https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0.pom
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.pom
Downloading https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2.pom
Downloaded https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0.pom
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.pom
Downloaded https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2.pom
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-parent/1.7.30/slf4j-parent-1.7.30.pom
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-parent/1.7.30/slf4j-parent-1.7.30.pom
Downloading https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0.jar
Downloading https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-util_2.13/1.9.6/scalate-util_2.13-1.9.6-sources.jar
Downloading https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2.jar
Downloading https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0-sources.jar
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30-sources.jar
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar
Downloaded https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-util_2.13/1.9.6/scalate-util_2.13-1.9.6-sources.jar
Downloading https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2-sources.jar
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30-sources.jar
Downloading https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-core_2.13/1.9.6/scalate-core_2.13-1.9.6.jar
Downloaded https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0-sources.jar
Downloading https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-util_2.13/1.9.6/scalate-util_2.13-1.9.6.jar
Downloaded https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2-sources.jar
Downloading https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-core_2.13/1.9.6/scalate-core_2.13-1.9.6-sources.jar
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar
Downloaded https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-util_2.13/1.9.6/scalate-util_2.13-1.9.6.jar
Downloaded https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-core_2.13/1.9.6/scalate-core_2.13-1.9.6-sources.jar
Downloaded https://repo1.maven.org/maven2/org/scalatra/scalate/scalate-core_2.13/1.9.6/scalate-core_2.13-1.9.6.jar
Downloaded https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2.jar
Downloaded https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0.jar
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.pom
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.pom
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30-sources.jar
Downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.jar
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.jar
Downloaded https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30-sources.jar
Compiling /src/core/build.sc
[30/41] blinky.compile
Compiling compiler interface...
[info] Compiling 4 Scala sources to /src/core/out/blinky/compile/dest/classes ...
[warn] 5 feature warnings; re-run with -feature for details
[warn] one warning found
[info] Done compiling.
[41/41] blinky.run
Elaborating design...
Done elaborating.
INFO: Setting up project
INFO: Set Libero tool option range to default value IND
INFO: Cores and Libero TCL Scripts generated.
```

