### PR TITLE
Chisel: Add projectdir config option

### DIFF
--- a/chisel.py
+++ b/chisel.py
@@ -14,6 +14,7 @@ class ChiselGenerator(Generator):
         chiselproject = self.config.get('chiselproject', None)
         outputdir = self.config.get('outputdir', "generated")
         extraargs = self.config.get('extraargs', "")
+        projectdir = self.config.get("projectdir", None)
         if buildtool == "mill" and chiselproject == None:
             print("The parameter 'chiselproject' must be defined.")
             exit(1)
@@ -24,7 +25,7 @@ class ChiselGenerator(Generator):
             shutil.copytree(self.files_root, tmp_dir,
                             ignore=shutil.ignore_patterns('out', 'generated'))
 
-        cwd = tmp_dir if copy_core else self.files_root
+        cwd = (tmp_dir if copy_core else self.files_root) + ("/" + projectdir if projectdir else "")
 
         files = self.config['output'].get('files', [])
         parameters = self.config['output'].get('parameters', {})


### PR DESCRIPTION
This option allows the user to specify the relative path of the chisel project.

Not sure if this is the right way to go about this but it's what I needed to use to get sbt to run in a subdirectory of my project. I feel like I must be missing something...